### PR TITLE
Make library usable outside for sure.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,4 @@
-module sshaws
-
-go 1.12
+module github.com/uritau/sshaws
 
 require (
 	github.com/aws/aws-sdk-go v1.34.18
@@ -10,3 +8,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
+
+go 1.12
+


### PR DESCRIPTION
We forgot to make de go module open for github.