### PR TITLE
Use only instance name tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 
 > It will show a list of instances depending on some specified tags and help you to ssh on it.
 
-
 ## Getting Started
-> Limitations: sshaws will only display instances with Environment and Application tags defined.
+
 ```bash
-usage: sshaws [-e Environment_tag] [-n instance_name] [-a Application_tag] [--silent true] [--region xx_yy_j] [-l user ][instance_name] [-ssh options]
+usage: sshaws [-n instance_name] [--silent true] [--region xx_yy_j] [-l user ][instance_name] [-ssh options]
 ```
+
 ### Examples
+
 ```bash
 # List all the instances from eu-west-1
 > sshaws
 
-Application: *   Environment: *   Name: *   Region: eu-west-1
+Name: *   Region: eu-west-1
 ---------------------------------------------------------
 
 [0] front-prod-1 - 172.16.31.12 (i-0978df6a92b39d434, t2.nano)
@@ -35,7 +36,7 @@ Which one do you want to ssh in?
 # List all the instances with front on name, from eu-west-1
 > sshaws front
 
-Application: *   Environment: *   Name: front   Region: eu-west-1
+Name: front   Region: eu-west-1
 ---------------------------------------------------------
 
 [0] front-prod-1 - 172.16.31.12 (i-0978df6a92b39d434, t2.nano)
@@ -48,65 +49,12 @@ Which one do you want to ssh in?
 [...] Stablishing SSH connection with the desired server
  ```
 
-```bash
-# List all the instances from eu-west-1 with TAG Environment=staging
-> sshaws -e staging
-
-Application: *   Environment: staging   Name: *   Region: eu-west-1
----------------------------------------------------------
-
-[0] front-staging - 172.16.39.121 (i-0b3914e89237829ad1, t2.micro)
-[1] back-staging - 172.16.19.93 (i-0b391351e237829ad1, t3.micro)
-
-Which one do you want to ssh in?
-# WAITING INPUT FROM USER
-1
->> Starting a new ssh session to 172.16.19.93
-[...] Stablishing SSH connection with the desired server
- ```
-
-```bash
-# List all the instances from eu-west-1 with TAG Environment=staging and back in the name
-> sshaws -e staging back
-
-Application: *   Environment: staging   Name: back   Region: eu-west-1
----------------------------------------------------------
-
-[0] back-staging - 172.16.19.93 (i-0b391351e237829ad1, t3.micro)
-
->> Starting a new ssh session to 172.31.2.93
-# If  there is only one instance, it will launch ssh automatically without waiting user input
-[...] Stablishing SSH connection with the desired server
-```
-
-```bash
-# List all the instances from eu-west-1 with TAG Environment=staging and launching ssh with user "test"
-> sshaws -e staging -l test
-
-Application: *   Environment: staging   Name: *   Region: eu-west-1
----------------------------------------------------------
-
-[0] front-staging - 172.16.39.121 (i-0b3914e89237829ad1, t2.micro)
-[1] back-staging - 172.16.19.93 (i-0b391351e237829ad1, t3.micro)
-
-Which one do you want to ssh in?
-# WAITING INPUT FROM USER
-0
->> Starting a new ssh session to test@172.31.36.121
-[...] Stablishing SSH connection with the desired server
- ```
-
-
 ### Usage in depth
 
 Download the binary in this repository and execute it, or compile by yourself following the next steps.
 
 ```bash
 sshaws
-  --app | -a
-        Tag Application of the instance (default "*")
-  --env | -e
-        Tag Environment of the instance (default "*")
   --name | -n
         Instance Name (default "*")
   -l string

--- a/cmd/sshaws/main.go
+++ b/cmd/sshaws/main.go
@@ -11,8 +11,6 @@ import (
 
 func main() {
 	var (
-		app            string
-		env            string
 		name           string
 		region         string
 		displayVersion bool
@@ -22,10 +20,6 @@ func main() {
 	)
 
 	const (
-		defaultApp    = "*"
-		usageApp      = "Tag Application of the instance"
-		defaultEnv    = "*"
-		usageEnv      = "Tag Environment of the instance"
 		defaultName   = "*"
 		usageName     = "Instance Name"
 		defaultRegion = "eu-west-1"
@@ -38,13 +32,9 @@ func main() {
 		usageSSH      = "Use SSH instead of SSM"
 	)
 
-	flag.StringVar(&app, "app", defaultApp, usageApp)
-	flag.StringVar(&env, "env", defaultEnv, usageEnv)
 	flag.StringVar(&name, "name", defaultName, usageName)
 	flag.BoolVar(&silent, "silent", defaultSilent, usageSilent)
 	flag.BoolVar(&ssh, "ssh", defaultSSH, usageSSH+" [short mode]")
-	flag.StringVar(&app, "a", defaultApp, usageApp+" [short mode]")
-	flag.StringVar(&env, "e", defaultEnv, usageEnv+" [short mode]")
 	flag.StringVar(&name, "n", defaultName, usageName+" [short mode]")
 	flag.StringVar(&region, "region", defaultRegion, usageRegion)
 	flag.BoolVar(&displayVersion, "version", false, "Display app version")
@@ -61,5 +51,5 @@ func main() {
 		name = flag.Args()[0]
 	}
 
-	auth.NewLogin(env, app, name, region, username, silent, ssh)
+	auth.NewLogin(name, region, username, silent, ssh)
 }

--- a/pkg/cmd/login/filterInstances.go
+++ b/pkg/cmd/login/filterInstances.go
@@ -9,9 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-func filterInstances(region, env, app, name string, silent bool, ssh bool) *ec2.DescribeInstancesOutput {
+func filterInstances(region, name string, silent bool, ssh bool) *ec2.DescribeInstancesOutput {
 	if !silent {
-		fmt.Printf("\nApplication: %s   Environment: %s   Name: %s   Region: %s\n", app, env, name, region)
+		fmt.Printf("\nName: %s   Region: %s\n", name, region)
 		fmt.Printf("---------------------------------------------------------\n\n")
 	}
 	sess, err := session.NewSession(&aws.Config{
@@ -21,17 +21,10 @@ func filterInstances(region, env, app, name string, silent bool, ssh bool) *ec2.
 	params := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:Environment"),
-				Values: []*string{aws.String(env)},
-			},
-			{
 				Name:   aws.String("tag:Name"),
 				Values: []*string{aws.String("*" + name + "*")},
 			},
 			{
-				Name:   aws.String("tag:Application"),
-				Values: []*string{aws.String(app + "*")},
-			}, {
 				Name:   aws.String("instance-state-name"),
 				Values: []*string{aws.String("running"), aws.String("pending")},
 			},

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -7,8 +7,8 @@ import (
 )
 
 // NewLogin login to the selected instance.
-func NewLogin(env string, app string, name string, region string, user string, silent bool, ssh bool) {
-	rawInstanceList := filterInstances(region, env, app, name, silent, ssh)
+func NewLogin(name string, region string, user string, silent bool, ssh bool) {
+	rawInstanceList := filterInstances(region, name, silent, ssh)
 	instances := getInstancesInfo(rawInstanceList)
 
 	if silent {


### PR DESCRIPTION
To simplify the usage of the app, we are getting rid of application and environment parsing. It's enough with tag name, and this will make sshaws more generic too.