### PR TITLE
Add launch date to output.

### DIFF
--- a/pkg/cmd/login/getInstancesInfo.go
+++ b/pkg/cmd/login/getInstancesInfo.go
@@ -14,7 +14,15 @@ func getInstancesInfo(describeInstancesOutput *ec2.DescribeInstancesOutput) []In
 					name = *tag.Value
 				}
 			}
-			newInstance := NewInstance(name, *inst.PrivateIpAddress, *inst.InstanceId, *inst.InstanceType, *inst.Placement.AvailabilityZone)
+
+			newInstance := NewInstance(
+				name,
+				*inst.PrivateIpAddress,
+				*inst.InstanceId,
+				*inst.InstanceType,
+				*inst.Placement.AvailabilityZone,
+				*inst.LaunchTime,
+			)
 			instanceList = append(instanceList, *newInstance)
 		}
 	}

--- a/pkg/cmd/login/instance.go
+++ b/pkg/cmd/login/instance.go
@@ -1,21 +1,25 @@
 package login
 
+import "time"
+
 //Instance struct
 type Instance struct {
-	Name string
-	IP   string
-	ID   string
-	Size string
-	AZ   string
+	Name       string
+	IP         string
+	ID         string
+	Size       string
+	AZ         string
+	LaunchTime time.Time
 }
 
 //NewInstance initialize struct Instnace.
-func NewInstance(name, ip, id, size, az string) *Instance {
+func NewInstance(name, ip, id, size, az string, launchTime time.Time) *Instance {
 	newInstance := new(Instance)
 	newInstance.Name = name
 	newInstance.IP = ip
 	newInstance.ID = id
 	newInstance.Size = size
 	newInstance.AZ = az
+	newInstance.LaunchTime = launchTime
 	return newInstance
 }

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -43,8 +43,17 @@ func showInstanceList(instanceList []Instance, user string) {
 		fmt.Printf("There are no instances matching your request.\n")
 		os.Exit(0)
 	}
+
 	for idx, inst := range instanceList {
-		fmt.Printf("[%d] %s - %s (%s, %s) \n", idx, inst.Name, inst.IP, inst.ID, inst.Size)
+		fmt.Printf(
+			"[%d] %s - %s (%s, %s, %s) \n",
+			idx,
+			inst.Name,
+			inst.IP,
+			inst.ID,
+			inst.Size,
+			inst.LaunchTime.Format("2006-01-02 15:04:05"),
+		)
 	}
 }
 


### PR DESCRIPTION
So it's easier to see which is the latest instance created. Sometimes it would be superuseful.

And if this is accepted we could do some kind of sorting in further PRs.

Example:

![image](https://user-images.githubusercontent.com/994837/112383778-da261a00-8ced-11eb-9fe6-3cf80e1515f3.png)

Documentation:
* https://golang.org/pkg/time/#Time.Format
* https://machiel.me/post/time-in-go-a-primer/