### PR TITLE
Improve ouput indentation.

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -66,7 +66,7 @@ func showInstanceList(instanceList []Instance, user string) {
 	table.SetAutoWrapText(false)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
-	table.SetTablePadding("\t")
+	table.SetTablePadding(" ")
 	table.SetNoWhiteSpace(true)
 	table.AppendBulk(tableData)
 	table.Render()


### PR DESCRIPTION
# Improve output indentation
We are changing tabs for spaces in the ouput indentation to fit better in the tiny screens.

Example:
![image](https://user-images.githubusercontent.com/994837/116086473-24f5d180-a6a0-11eb-9ffb-5d8ceba36e52.png)

